### PR TITLE
Added timestamps to plugin log

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	lightning "github.com/fiatjaf/lightningd-gjson-rpc"
 )
@@ -122,11 +123,13 @@ func (p *Plugin) Listener(initialized chan<- bool) {
 	// logging
 	prefix := p.colorize("plugin-" + p.Name)
 	p.Log = func(args ...interface{}) {
-		args = append([]interface{}{prefix + " "}, args...)
+		timestamp := time.Now().Format("2006-01-02T15:04:05.999Z")
+		args = append([]interface{}{timestamp, prefix}, args...)
 		fmt.Fprintln(os.Stderr, args...)
 	}
 	p.Logf = func(b string, args ...interface{}) {
-		fmt.Fprintf(os.Stderr, prefix+" "+b+"\n", args...)
+		timestamp := time.Now().Format("2006-01-02T15:04:05.999Z")
+		fmt.Fprintf(os.Stderr, timestamp+" "+prefix+" "+b+"\n", args...)
 	}
 
 	var msg lightning.JSONRPCMessage


### PR DESCRIPTION
This adds timestamps to the plugins output. Bringing it in line with standard CLN output

![image](https://user-images.githubusercontent.com/16665772/220440011-01567d03-212b-4869-9b0f-f1821ad86fde.png)
