### PR TITLE
Implement shutdown notification

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,7 +20,7 @@ To instantiate your `Plugin` struct you'll need some values:
 
 From inside the functions and handlers you'll have access to a `plugin.Plugin` struct with `Args`, the set of options passed to the plugins from lightningd initialization; `Log` and `Logf`, basic logging functions that will print a line to the lightningd logs prefixed with your plugin name; and `Client`, a [lightningd-gjson-rpc](https://godoc.org/github.com/fiatjaf/lightningd-gjson-rpc#Client) client you can use to call methods on lightningd.
 
-With the above, the [![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/fiatjaf/lightningd-gjson-rpc/plugin) and the [Plugins docs](https://lightning.readthedocs.io/PLUGINS.html#hooks) you'll be able to make any plugin you want.
+With the above, the [![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/fiatjaf/lightningd-gjson-rpc/plugin) and the [Plugins docs](https://docs.corelightning.org/docs/plugin-development) you'll be able to make any plugin you want.
 
 ## Example plugin
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -35,9 +35,9 @@ type Plugin struct {
 	Dynamic       bool                `json:"dynamic"`
 	Notifications []NotificationTopic `json:"notifications"`
 
-	Configuration  Params            `json:"-"`
-	Args   Params        `json:"-"`
-	OnInit func(*Plugin) `json:"-"`
+	Configuration Params        `json:"-"`
+	Args          Params        `json:"-"`
+	OnInit        func(*Plugin) `json:"-"`
 }
 
 type Features struct {
@@ -223,6 +223,11 @@ func (p *Plugin) Listener(initialized chan<- bool) {
 				Version: msg.Version,
 				Id:      msg.Id,
 			})
+		case "shutdown":
+			if shutdown, ok := submap["shutdown"]; ok {
+				shutdown.Handler(p, msg.Params.(map[string]interface{}))
+			}
+			return
 		default:
 			go handleMessage(p, outgoing, msg)
 		}


### PR DESCRIPTION
Core Lightning has an event notification to signal [shutdown](https://docs.corelightning.org/docs/event-notifications#shutdown) to its plugins, so they have a chance to exit cleanly. This would be useful for plugins that need to do some cleanup before shutdown, and for testing the plugins in general.

I've simply added an extra case in the switch to exit the main loop when a shutdown is received. If the plugin registers a handler for the shutdown notification it is executed before exiting the loop.

PS I don't run the shutdown handler in its own goroutine because it simplifies the shutdown itself, but I don't think this is problematic because by definition it's the last command the plugin receives.